### PR TITLE
Minor fix to build on MacOS and remove linking of vtkMNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,6 @@ else()
 
 endif()
 
-# Include directories
-add_subdirectory(utils)
 
 #================================
 # Define output
@@ -110,11 +108,14 @@ add_subdirectory(utils)
 set( libName GPURigidRegistrationLib )
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_library( ${libName} ${SRC_files} ${HDR_files} ${SRC_CL} ${HDR_CL} )
-target_link_libraries( ${libName} ${ITK_LIBRARIES}  ${VTK_LIBRARIES} ${ELASTIX_LIBRARIES} vtkMNI )
+target_link_libraries( ${libName} ${ITK_LIBRARIES}  ${VTK_LIBRARIES} ${ELASTIX_LIBRARIES} )
 target_include_directories( ${libName} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )
 
+# Build vtkMNI utility lib (only needed by the executable)
+add_subdirectory(utils)
+
 add_executable( GPURigidRegistration main.cpp )
-target_link_libraries( GPURigidRegistration ${libName} )
+target_link_libraries( GPURigidRegistration ${libName} vtkMNI )
 
 #================================
 # Define tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,6 @@ add_test(NAME ImageRegistrationTest COMMAND ImageRegistrationTest ${TestDataDir}
 add_test(NAME ImageRegistrationWithInitialTransformTest COMMAND ImageRegistrationWithInitialTransformTest ${TestDataDir})
 add_test(NAME ImageRegistrationWithMaskTest COMMAND ImageRegistrationWithMaskTest ${TestDataDir})
 
-target_link_libraries( ImageRegistrationTest ${VTK_LIBRARIES} ${libName} ${vtkMNI} )
-target_link_libraries( ImageRegistrationWithInitialTransformTest ${VTK_LIBRARIES} ${libName} ${vtkMNI} )
-target_link_libraries( ImageRegistrationWithMaskTest ${VTK_LIBRARIES} ${libName} ${vtkMNI} )
+target_link_libraries( ImageRegistrationTest ${VTK_LIBRARIES} ${libName} vtkMNI )
+target_link_libraries( ImageRegistrationWithInitialTransformTest ${VTK_LIBRARIES} ${libName} vtkMNI )
+target_link_libraries( ImageRegistrationWithMaskTest ${VTK_LIBRARIES} ${libName} vtkMNI )

--- a/tests/ComputeAccuracy.cxx
+++ b/tests/ComputeAccuracy.cxx
@@ -6,6 +6,7 @@
 
 #include <string> 
 #include <iostream>
+#include <cmath>
 
 // accuracy threshold to pass the test in mm
 #define THRESHOLD 3 


### PR DESCRIPTION
vtkMNI util lib is only linked with executables in the repository, and not lib to avoid colision with similar lib in Ibis.